### PR TITLE
Move all tagging to ripper-tags

### DIFF
--- a/bin/prs
+++ b/bin/prs
@@ -1,0 +1,1 @@
+hub pr list -f "%au %H %U%n" | grep geoffharcourt | column -t

--- a/config/alacritty/alacritty.yml
+++ b/config/alacritty/alacritty.yml
@@ -82,19 +82,19 @@ tabspaces: 8
 font:
   # Normal (roman) font face
   normal:
-    family: Source Code Pro
+    family: Pitch
     # The `style` can be specified to pick a specific face.
-    style: Medium
+    style: Regular
 
   # Italic font face
   bold:
-    family: Source Code Pro
+    family: Pitch
     # The `style` can be specified to pick a specific face.
     style: Bold
 
   # Italic font face
   italic:
-    family: Source Code Pro
+    family: Pitch
     # The `style` can be specified to pick a specific face.
     style: Italic
 

--- a/default-gems
+++ b/default-gems
@@ -1,6 +1,6 @@
-gem-ctags
 bundler
 gem-browse
+gem-ripper-tags
 gem-shut-the-fuck-up
 neovim
 parity

--- a/git_template/hooks/ctags
+++ b/git_template/hooks/ctags
@@ -5,7 +5,5 @@ set -e
 PATH="/usr/local/bin:$PATH"
 dir="$(git rev-parse --git-dir)"
 trap 'rm -f "$dir/$$.tags"' EXIT
-# git ls-files | \
-#   "${CTAGS:-ctags}" --tag-relative=yes -L - -f"$dir/$$.tags" --languages=-javascript,sql
-ripper-tags -R --exclude=vendor -f"$dir/$$.tags" --tag-relative
+ripper-tags -R -f"$dir/$$.tags" --tag-relative
 mv "$dir/$$.tags" "$dir/tags"

--- a/vimrc.bundles.local
+++ b/vimrc.bundles.local
@@ -30,3 +30,5 @@ Plug 'leafgarland/typescript-vim'
 Plug 'HerringtonDarkholme/yats.vim'
 Plug 'skwp/greplace.vim'
 
+" Experiments
+Plug 'bogado/file-line'

--- a/vimrc.local
+++ b/vimrc.local
@@ -123,8 +123,6 @@ autocmd VimEnter * RainbowParentheses .
 " Autocompletion
 """
 
-autocmd CursorHold * silent call CocActionAsync('highlight')
-
 function! s:check_back_space()
   let line = getline('.')                    " current line
   let substr = strpart(line, -1, col('.')+1) " from the start of the current


### PR DESCRIPTION
LSP has been serving as my jump-to-definition solution for all languages,
but sometimes Solargraph loads slowly and I like to be able to leverage
ctags-like functionality. With the discovery of
`gem-ripper-tags`, I'm now on a ctags-free setup. This change replaces the
thoughtbot git hook to use ripper-tags.