### PR TITLE
Restore .git/tags support

### DIFF
--- a/vimrc.local
+++ b/vimrc.local
@@ -176,6 +176,8 @@ nnoremap <silent> K :CocList --auto-preview grep <C-R><C-W><CR>
 nnoremap \ :Find<Space>
 nnoremap <C-P> :Files<CR>
 
+set tags^=./.git/tags;
+
 " Jump to the first result if only one tag match,
 " otherwise show the candidates list
 nnoremap <C-]> <Esc>:exe "tjump " . expand("<cword>")<Esc>


### PR DESCRIPTION
vim-fugitive used to put this at the front of the tagfiles so that your
local tags came before gems, etc, but that changed in https://github.com/tpope/vim-fugitive/commit/63a05a6935ec4a45551bf141089c13d5671202a1.

This change brings it back with the recommendation mentioned in that
commit.